### PR TITLE
Add numeric instances for Gen

### DIFF
--- a/test-refined/shared/src/main/scala/zio/test/refined/NumericInstances.scala
+++ b/test-refined/shared/src/main/scala/zio/test/refined/NumericInstances.scala
@@ -10,52 +10,52 @@ object numeric extends NumericInstances
 
 trait NumericInstances {
 
-  def intGreaterThan[N](implicit
+  implicit def intGreaterThan[N](implicit
     wn: WitnessAs[N, Int]
   ): DeriveGen[Int Refined Greater[N]] =
     DeriveGen.instance(Gen.int(wn.snd, Int.MaxValue).map(Refined.unsafeApply))
 
-  def longGreaterThan[N](implicit
+  implicit def longGreaterThan[N](implicit
     wn: WitnessAs[N, Long]
   ): DeriveGen[Long Refined Greater[N]] =
     DeriveGen.instance(Gen.long(wn.snd, Long.MaxValue).map(Refined.unsafeApply))
 
-  def shortGreaterThan[N](implicit
+  implicit def shortGreaterThan[N](implicit
     wn: WitnessAs[N, Short]
   ): DeriveGen[Short Refined Greater[N]] =
     DeriveGen.instance(Gen.short(wn.snd, Short.MaxValue).map(Refined.unsafeApply))
 
-  def byteGreaterThan[N](implicit
+  implicit def byteGreaterThan[N](implicit
     wn: WitnessAs[N, Byte]
   ): DeriveGen[Byte Refined Greater[N]] =
     DeriveGen.instance(Gen.byte(wn.snd, Byte.MaxValue).map(Refined.unsafeApply))
 
-  def doubleGreaterThan[N](implicit
+  implicit def doubleGreaterThan[N](implicit
     wn: WitnessAs[N, Double]
   ): DeriveGen[Double Refined Greater[N]] =
     DeriveGen.instance(Gen.double(wn.snd, Double.MaxValue).map(Refined.unsafeApply))
 
-  def intLessThan[N](implicit
+  implicit def intLessThan[N](implicit
     wn: WitnessAs[N, Int]
   ): DeriveGen[Int Refined Less[N]] =
     DeriveGen.instance(Gen.int(Int.MinValue, wn.snd).map(Refined.unsafeApply))
 
-  def longLessThan[N](implicit
+  implicit def longLessThan[N](implicit
     wn: WitnessAs[N, Long]
   ): DeriveGen[Long Refined Less[N]] =
     DeriveGen.instance(Gen.long(Long.MinValue, wn.snd).map(Refined.unsafeApply))
 
-  def shortLessThan[N](implicit
+  implicit def shortLessThan[N](implicit
     wn: WitnessAs[N, Short]
   ): DeriveGen[Short Refined Less[N]] =
     DeriveGen.instance(Gen.short(Short.MinValue, wn.snd).map(Refined.unsafeApply))
 
-  def byteLessThan[N](implicit
+  implicit def byteLessThan[N](implicit
     wn: WitnessAs[N, Byte]
   ): DeriveGen[Byte Refined Less[N]] =
     DeriveGen.instance(Gen.byte(Byte.MinValue, wn.snd).map(Refined.unsafeApply))
 
-  def doubleLessThan[N](implicit
+  implicit def doubleLessThan[N](implicit
     wn: WitnessAs[N, Double]
   ): DeriveGen[Double Refined Less[N]] =
     DeriveGen.instance(Gen.double(Double.MinValue, wn.snd).map(Refined.unsafeApply))

--- a/test-refined/shared/src/main/scala/zio/test/refined/NumericInstances.scala
+++ b/test-refined/shared/src/main/scala/zio/test/refined/NumericInstances.scala
@@ -1,0 +1,63 @@
+package zio.test.refined
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.internal.WitnessAs
+import eu.timepit.refined.numeric.{Greater, Less}
+import zio.random.Random
+import zio.test.Gen
+
+object numeric extends NumericInstances
+
+trait NumericInstances {
+
+  def intGreaterThan[N](implicit
+                        wn: WitnessAs[N, Int]
+                       ): Gen[Random, Int Refined Greater[N]] =
+    Gen.int(wn.snd, Int.MaxValue).map(Refined.unsafeApply)
+
+  def longGreaterThan[N](implicit
+                         wn: WitnessAs[N, Long]
+                        ): Gen[Random, Long Refined Greater[N]] =
+    Gen.long(wn.snd, Long.MaxValue).map(Refined.unsafeApply)
+
+  def shortGreaterThan[N](implicit
+                          wn: WitnessAs[N, Short]
+                         ): Gen[Random, Short Refined Greater[N]] =
+    Gen.short(wn.snd, Short.MaxValue).map(Refined.unsafeApply)
+
+  def byteGreaterThan[N](implicit
+                         wn: WitnessAs[N, Byte]
+                        ): Gen[Random, Byte Refined Greater[N]] =
+    Gen.byte(wn.snd, Byte.MaxValue).map(Refined.unsafeApply)
+
+  def doubleGreaterThan[N](implicit
+                           wn: WitnessAs[N, Double]
+                          ): Gen[Random, Double Refined Greater[N]] =
+    Gen.double(wn.snd, Double.MaxValue).map(Refined.unsafeApply)
+
+  def intLessThan[N](implicit
+                     wn: WitnessAs[N, Int]
+                    ): Gen[Random, Int Refined Less[N]] =
+    Gen.int(Int.MinValue, wn.snd).map(Refined.unsafeApply)
+
+  def longLessThan[N](implicit
+                      wn: WitnessAs[N, Long]
+                     ): Gen[Random, Long Refined Less[N]] =
+    Gen.long(Long.MinValue, wn.snd).map(Refined.unsafeApply)
+
+  def shortLessThan[N](implicit
+                       wn: WitnessAs[N, Short]
+                      ): Gen[Random, Short Refined Less[N]] =
+    Gen.short(Short.MinValue, wn.snd).map(Refined.unsafeApply)
+
+  def byteLessThan[N](implicit
+                      wn: WitnessAs[N, Byte]
+                     ): Gen[Random, Byte Refined Less[N]] =
+    Gen.byte(Byte.MinValue, wn.snd).map(Refined.unsafeApply)
+
+  def doubleLessThan[N](implicit
+                        wn: WitnessAs[N, Double]
+                       ): Gen[Random, Double Refined Less[N]] =
+    Gen.double(Double.MinValue, wn.snd).map(Refined.unsafeApply)
+
+}

--- a/test-refined/shared/src/main/scala/zio/test/refined/NumericInstances.scala
+++ b/test-refined/shared/src/main/scala/zio/test/refined/NumericInstances.scala
@@ -3,8 +3,8 @@ package zio.test.refined
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.internal.WitnessAs
 import eu.timepit.refined.numeric.{Greater, Less}
-import zio.random.Random
 import zio.test.Gen
+import zio.test.magnolia.DeriveGen
 
 object numeric extends NumericInstances
 
@@ -12,52 +12,52 @@ trait NumericInstances {
 
   def intGreaterThan[N](implicit
     wn: WitnessAs[N, Int]
-  ): Gen[Random, Int Refined Greater[N]] =
-    Gen.int(wn.snd, Int.MaxValue).map(Refined.unsafeApply)
+  ): DeriveGen[Int Refined Greater[N]] =
+    DeriveGen.instance(Gen.int(wn.snd, Int.MaxValue).map(Refined.unsafeApply))
 
   def longGreaterThan[N](implicit
     wn: WitnessAs[N, Long]
-  ): Gen[Random, Long Refined Greater[N]] =
-    Gen.long(wn.snd, Long.MaxValue).map(Refined.unsafeApply)
+  ): DeriveGen[Long Refined Greater[N]] =
+    DeriveGen.instance(Gen.long(wn.snd, Long.MaxValue).map(Refined.unsafeApply))
 
   def shortGreaterThan[N](implicit
     wn: WitnessAs[N, Short]
-  ): Gen[Random, Short Refined Greater[N]] =
-    Gen.short(wn.snd, Short.MaxValue).map(Refined.unsafeApply)
+  ): DeriveGen[Short Refined Greater[N]] =
+    DeriveGen.instance(Gen.short(wn.snd, Short.MaxValue).map(Refined.unsafeApply))
 
   def byteGreaterThan[N](implicit
     wn: WitnessAs[N, Byte]
-  ): Gen[Random, Byte Refined Greater[N]] =
-    Gen.byte(wn.snd, Byte.MaxValue).map(Refined.unsafeApply)
+  ): DeriveGen[Byte Refined Greater[N]] =
+    DeriveGen.instance(Gen.byte(wn.snd, Byte.MaxValue).map(Refined.unsafeApply))
 
   def doubleGreaterThan[N](implicit
     wn: WitnessAs[N, Double]
-  ): Gen[Random, Double Refined Greater[N]] =
-    Gen.double(wn.snd, Double.MaxValue).map(Refined.unsafeApply)
+  ): DeriveGen[Double Refined Greater[N]] =
+    DeriveGen.instance(Gen.double(wn.snd, Double.MaxValue).map(Refined.unsafeApply))
 
   def intLessThan[N](implicit
     wn: WitnessAs[N, Int]
-  ): Gen[Random, Int Refined Less[N]] =
-    Gen.int(Int.MinValue, wn.snd).map(Refined.unsafeApply)
+  ): DeriveGen[Int Refined Less[N]] =
+    DeriveGen.instance(Gen.int(Int.MinValue, wn.snd).map(Refined.unsafeApply))
 
   def longLessThan[N](implicit
     wn: WitnessAs[N, Long]
-  ): Gen[Random, Long Refined Less[N]] =
-    Gen.long(Long.MinValue, wn.snd).map(Refined.unsafeApply)
+  ): DeriveGen[Long Refined Less[N]] =
+    DeriveGen.instance(Gen.long(Long.MinValue, wn.snd).map(Refined.unsafeApply))
 
   def shortLessThan[N](implicit
     wn: WitnessAs[N, Short]
-  ): Gen[Random, Short Refined Less[N]] =
-    Gen.short(Short.MinValue, wn.snd).map(Refined.unsafeApply)
+  ): DeriveGen[Short Refined Less[N]] =
+    DeriveGen.instance(Gen.short(Short.MinValue, wn.snd).map(Refined.unsafeApply))
 
   def byteLessThan[N](implicit
     wn: WitnessAs[N, Byte]
-  ): Gen[Random, Byte Refined Less[N]] =
-    Gen.byte(Byte.MinValue, wn.snd).map(Refined.unsafeApply)
+  ): DeriveGen[Byte Refined Less[N]] =
+    DeriveGen.instance(Gen.byte(Byte.MinValue, wn.snd).map(Refined.unsafeApply))
 
   def doubleLessThan[N](implicit
     wn: WitnessAs[N, Double]
-  ): Gen[Random, Double Refined Less[N]] =
-    Gen.double(Double.MinValue, wn.snd).map(Refined.unsafeApply)
+  ): DeriveGen[Double Refined Less[N]] =
+    DeriveGen.instance(Gen.double(Double.MinValue, wn.snd).map(Refined.unsafeApply))
 
 }

--- a/test-refined/shared/src/main/scala/zio/test/refined/NumericInstances.scala
+++ b/test-refined/shared/src/main/scala/zio/test/refined/NumericInstances.scala
@@ -11,53 +11,53 @@ object numeric extends NumericInstances
 trait NumericInstances {
 
   def intGreaterThan[N](implicit
-                        wn: WitnessAs[N, Int]
-                       ): Gen[Random, Int Refined Greater[N]] =
+    wn: WitnessAs[N, Int]
+  ): Gen[Random, Int Refined Greater[N]] =
     Gen.int(wn.snd, Int.MaxValue).map(Refined.unsafeApply)
 
   def longGreaterThan[N](implicit
-                         wn: WitnessAs[N, Long]
-                        ): Gen[Random, Long Refined Greater[N]] =
+    wn: WitnessAs[N, Long]
+  ): Gen[Random, Long Refined Greater[N]] =
     Gen.long(wn.snd, Long.MaxValue).map(Refined.unsafeApply)
 
   def shortGreaterThan[N](implicit
-                          wn: WitnessAs[N, Short]
-                         ): Gen[Random, Short Refined Greater[N]] =
+    wn: WitnessAs[N, Short]
+  ): Gen[Random, Short Refined Greater[N]] =
     Gen.short(wn.snd, Short.MaxValue).map(Refined.unsafeApply)
 
   def byteGreaterThan[N](implicit
-                         wn: WitnessAs[N, Byte]
-                        ): Gen[Random, Byte Refined Greater[N]] =
+    wn: WitnessAs[N, Byte]
+  ): Gen[Random, Byte Refined Greater[N]] =
     Gen.byte(wn.snd, Byte.MaxValue).map(Refined.unsafeApply)
 
   def doubleGreaterThan[N](implicit
-                           wn: WitnessAs[N, Double]
-                          ): Gen[Random, Double Refined Greater[N]] =
+    wn: WitnessAs[N, Double]
+  ): Gen[Random, Double Refined Greater[N]] =
     Gen.double(wn.snd, Double.MaxValue).map(Refined.unsafeApply)
 
   def intLessThan[N](implicit
-                     wn: WitnessAs[N, Int]
-                    ): Gen[Random, Int Refined Less[N]] =
+    wn: WitnessAs[N, Int]
+  ): Gen[Random, Int Refined Less[N]] =
     Gen.int(Int.MinValue, wn.snd).map(Refined.unsafeApply)
 
   def longLessThan[N](implicit
-                      wn: WitnessAs[N, Long]
-                     ): Gen[Random, Long Refined Less[N]] =
+    wn: WitnessAs[N, Long]
+  ): Gen[Random, Long Refined Less[N]] =
     Gen.long(Long.MinValue, wn.snd).map(Refined.unsafeApply)
 
   def shortLessThan[N](implicit
-                       wn: WitnessAs[N, Short]
-                      ): Gen[Random, Short Refined Less[N]] =
+    wn: WitnessAs[N, Short]
+  ): Gen[Random, Short Refined Less[N]] =
     Gen.short(Short.MinValue, wn.snd).map(Refined.unsafeApply)
 
   def byteLessThan[N](implicit
-                      wn: WitnessAs[N, Byte]
-                     ): Gen[Random, Byte Refined Less[N]] =
+    wn: WitnessAs[N, Byte]
+  ): Gen[Random, Byte Refined Less[N]] =
     Gen.byte(Byte.MinValue, wn.snd).map(Refined.unsafeApply)
 
   def doubleLessThan[N](implicit
-                        wn: WitnessAs[N, Double]
-                       ): Gen[Random, Double Refined Less[N]] =
+    wn: WitnessAs[N, Double]
+  ): Gen[Random, Double Refined Less[N]] =
     Gen.double(Double.MinValue, wn.snd).map(Refined.unsafeApply)
 
 }

--- a/test-refined/shared/src/main/scala/zio/test/refined/all.scala
+++ b/test-refined/shared/src/main/scala/zio/test/refined/all.scala
@@ -6,3 +6,4 @@ object all
     with CollectionInstances
     with GenericInstances
     with StringInstances
+    with NumericInstances


### PR DESCRIPTION
I added instances returning Gen for numeric types. I'm not sure why in other cases (`CharInstances`) `DeriveGen` is returned instead. Is it because this way we have Magnolia type classes for free, and we can get the `Gen` just by calling `.derive` where necessary? In this case, I can easily update my PR to return `DeriveGen` as well